### PR TITLE
adding support for more subreddits, raising step up to only the top 1%

### DIFF
--- a/lambdaFunctions/getRedditDataFunction/lambda_function.py
+++ b/lambdaFunctions/getRedditDataFunction/lambda_function.py
@@ -13,7 +13,7 @@ def lambda_handler(event, context):
   subreddits = ["pics", "memes", "gaming", "worldnews", "news", "aww", "funny", "todayilearned", "movies"]
 
   # cfg_file = cu.findConfig()
-  cfg_file = 's3://data-kennethmyers/reddit2.cfg'
+  cfg_file = 's3://data-kennethmyers/reddit.cfg'
   cfg = cu.parseConfig(cfg_file)
 
   CLIENTID = cfg['reddit_api']['CLIENTID']

--- a/model/notebookArchive/model-GBM-20230505.ipynb
+++ b/model/notebookArchive/model-GBM-20230505.ipynb
@@ -2,19 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "20230510: Rerunning last section to increase step up threshold to top 1%. When I added more subreddits it started sending too many posts throughout the day and the model is not currently trained for the activity levels in the various subreddits. Increasing the threshold will reduce the amount it steps up."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "toc": true
    },
    "source": [
     "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
-    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Read-from-S3\" data-toc-modified-id=\"Read-from-S3-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Read from S3</a></span></li><li><span><a href=\"#Model\" data-toc-modified-id=\"Model-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Model</a></span></li><li><span><a href=\"#SHAP-analysis\" data-toc-modified-id=\"SHAP-analysis-3\"><span class=\"toc-item-num\">3&nbsp;&nbsp;</span>SHAP analysis</a></span></li><li><span><a href=\"#Grid-search-regularization-parameter\" data-toc-modified-id=\"Grid-search-regularization-parameter-4\"><span class=\"toc-item-num\">4&nbsp;&nbsp;</span>Grid search regularization parameter</a></span></li><li><span><a href=\"#Create-Final-Model-and-Save-Model\" data-toc-modified-id=\"Create-Final-Model-and-Save-Model-5\"><span class=\"toc-item-num\">5&nbsp;&nbsp;</span>Create Final Model and Save Model</a></span></li><li><span><a href=\"#Upload-Model-to-S3\" data-toc-modified-id=\"Upload-Model-to-S3-6\"><span class=\"toc-item-num\">6&nbsp;&nbsp;</span>Upload Model to S3</a></span></li><li><span><a href=\"#Get-Threshold-of-Top-1%-of-data\" data-toc-modified-id=\"Get-Threshold-of-Top-1%-of-data-7\"><span class=\"toc-item-num\">7&nbsp;&nbsp;</span>Get Threshold of Top 1% of data</a></span></li></ul></div>"
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Read-from-S3\" data-toc-modified-id=\"Read-from-S3-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Read from S3</a></span></li><li><span><a href=\"#Model\" data-toc-modified-id=\"Model-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Model</a></span></li><li><span><a href=\"#SHAP-analysis\" data-toc-modified-id=\"SHAP-analysis-3\"><span class=\"toc-item-num\">3&nbsp;&nbsp;</span>SHAP analysis</a></span></li><li><span><a href=\"#Grid-search-regularization-parameter\" data-toc-modified-id=\"Grid-search-regularization-parameter-4\"><span class=\"toc-item-num\">4&nbsp;&nbsp;</span>Grid search regularization parameter</a></span></li><li><span><a href=\"#Create-Final-Model-and-Save-Model\" data-toc-modified-id=\"Create-Final-Model-and-Save-Model-5\"><span class=\"toc-item-num\">5&nbsp;&nbsp;</span>Create Final Model and Save Model</a></span></li><li><span><a href=\"#Upload-Model-to-S3\" data-toc-modified-id=\"Upload-Model-to-S3-6\"><span class=\"toc-item-num\">6&nbsp;&nbsp;</span>Upload Model to S3</a></span></li><li><span><a href=\"#Get-Threshold-of-Top-~2%-of-data\" data-toc-modified-id=\"Get-Threshold-of-Top-~2%-of-data-7\"><span class=\"toc-item-num\">7&nbsp;&nbsp;</span>Get Threshold of Top ~2% of data</a></span></li></ul></div>"
    ]
   },
   {
@@ -22,8 +15,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:31:57.198159Z",
-     "start_time": "2023-05-10T18:31:57.142023Z"
+     "end_time": "2023-05-03T23:51:57.101290Z",
+     "start_time": "2023-05-03T23:51:56.971819Z"
     }
    },
    "outputs": [],
@@ -37,13 +30,13 @@
    "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:31:59.840540Z",
-     "start_time": "2023-05-10T18:31:57.328401Z"
+     "end_time": "2023-05-03T23:52:03.488857Z",
+     "start_time": "2023-05-03T23:51:57.595688Z"
     }
    },
    "outputs": [],
    "source": [
-    "import modelUtils as mu\n",
+    "import utils\n",
     "import pyarrow.parquet as pq\n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
@@ -51,11 +44,6 @@
     "from pyspark.sql import SparkSession\n",
     "import os\n",
     "import pandas as pd\n",
-    "import sys\n",
-    "sys.path.append('..')\n",
-    "import configUtils as cu\n",
-    "import pickle\n",
-    "\n",
     "\n",
     "os.environ['TZ'] = 'UTC'"
    ]
@@ -74,8 +62,8 @@
    "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:31:59.927659Z",
-     "start_time": "2023-05-10T18:31:59.847319Z"
+     "end_time": "2023-05-03T23:52:03.695903Z",
+     "start_time": "2023-05-03T23:52:03.532050Z"
     }
    },
    "outputs": [],
@@ -88,14 +76,14 @@
    "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:32:31.503506Z",
-     "start_time": "2023-05-10T18:31:59.943209Z"
+     "end_time": "2023-05-03T23:52:43.101747Z",
+     "start_time": "2023-05-03T23:52:03.718599Z"
     }
    },
    "outputs": [],
    "source": [
-    "cfg_file = cu.findConfig()\n",
-    "cfg = cu.parseConfig(cfg_file)\n",
+    "cfg_file = utils.findConfig()\n",
+    "cfg = utils.parseConfig(cfg_file)\n",
     "spark = (\n",
     "  SparkSession\n",
     "  .builder\n",
@@ -103,8 +91,8 @@
     "  .config('spark.driver.extraJavaOptions', '-Duser.timezone=GMT') \n",
     "  .config('spark.executor.extraJavaOptions', '-Duser.timezone=GMT')\n",
     "  .config('spark.sql.session.timeZone', 'UTC')\n",
-    "  .config(\"fs.s3a.access.key\", cfg['S3_access']['ACCESSKEY'])\n",
-    "  .config(\"fs.s3a.secret.key\", cfg['S3_access']['SECRETKEY'])\n",
+    "  .config(\"fs.s3a.access.key\", cfg['ACCESSKEY'])\n",
+    "  .config(\"fs.s3a.secret.key\", cfg['SECRETKEY'])\n",
     "  .getOrCreate()\n",
     ")\n",
     "df = spark.read.parquet(filename).toPandas()\n",
@@ -123,8 +111,8 @@
    "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:38:30.825618Z",
-     "start_time": "2023-05-10T18:38:30.325073Z"
+     "end_time": "2023-05-03T23:52:43.592899Z",
+     "start_time": "2023-05-03T23:52:43.108978Z"
     }
    },
    "outputs": [],
@@ -140,8 +128,8 @@
    "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:38:30.919898Z",
-     "start_time": "2023-05-10T18:38:30.832950Z"
+     "end_time": "2023-05-03T23:52:43.682868Z",
+     "start_time": "2023-05-03T23:52:43.608528Z"
     }
    },
    "outputs": [],
@@ -154,8 +142,8 @@
    "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:38:35.393700Z",
-     "start_time": "2023-05-10T18:38:35.310757Z"
+     "end_time": "2023-05-03T23:52:43.756141Z",
+     "start_time": "2023-05-03T23:52:43.692166Z"
     }
    },
    "outputs": [],
@@ -186,8 +174,8 @@
    "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:38:35.800002Z",
-     "start_time": "2023-05-10T18:38:35.531456Z"
+     "end_time": "2023-05-03T23:52:43.907443Z",
+     "start_time": "2023-05-03T23:52:43.759591Z"
     }
    },
    "outputs": [],
@@ -200,8 +188,8 @@
    "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:38:37.334015Z",
-     "start_time": "2023-05-10T18:38:37.257380Z"
+     "end_time": "2023-05-03T23:52:43.988703Z",
+     "start_time": "2023-05-03T23:52:43.910754Z"
     }
    },
    "outputs": [],
@@ -215,8 +203,8 @@
    "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:38:42.413707Z",
-     "start_time": "2023-05-10T18:38:42.300471Z"
+     "end_time": "2023-05-03T23:52:44.082155Z",
+     "start_time": "2023-05-03T23:52:43.993927Z"
     }
    },
    "outputs": [],
@@ -433,18 +421,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T19:07:41.021891Z",
-     "start_time": "2023-05-10T19:07:40.935663Z"
+     "end_time": "2023-05-03T23:55:38.448710Z",
+     "start_time": "2023-05-03T23:55:38.381911Z"
     }
    },
    "outputs": [],
    "source": [
     "# I wanted to see some data on the viral posts (why were some accurately predicted and some not)\n",
     "# and the posts that had high viral probability but were considered non-viral\n",
-    "def getOriginalPostId(df, test_index, y_test, y_pred_proba, threshold, features):\n",
+    "def getOriginalPostId(df, test_index, y_test, y_pred_proba, threshold):\n",
     "  fullTestData = df.iloc[test_index].copy(deep=True)\n",
     "  fullTestData['prediction'] = y_pred_proba\n",
     "  fullTestData['link'] = fullTestData['postId'].apply(lambda x: \"https://reddit.com/\"+x)\n",
@@ -1355,7 +1343,7 @@
     }
    ],
    "source": [
-    "getOriginalPostId(df, test_index, y_test, y_pred_proba, threshold=0.2, features=features)"
+    "getOriginalPostId(df, test_index, y_test, y_pred_proba, threshold=0.2)"
    ]
   },
   {
@@ -1992,6 +1980,7 @@
    },
    "outputs": [],
    "source": [
+    "import pickle\n",
     "from datetime import datetime\n",
     "\n",
     "now = datetime.utcnow().strftime('%Y%m%d-%H%M%S')\n",
@@ -2001,17 +1990,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:23:43.068876Z",
-     "start_time": "2023-05-10T18:23:42.289402Z"
+     "end_time": "2023-05-03T23:53:56.191703Z",
+     "start_time": "2023-05-03T23:53:56.106338Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.98341046 0.01658954]\n",
+      " [0.98352997 0.01647003]\n",
+      " [0.98352997 0.01647003]\n",
+      " ...\n",
+      " [0.98352997 0.01647003]\n",
+      " [0.98352997 0.01647003]\n",
+      " [0.98352997 0.01647003]]\n"
+     ]
+    }
+   ],
    "source": [
     "# testing the model\n",
-    "filename = './pickledModels/Reddit_model_20230503-235329_GBM.sav'\n",
     "loaded_model = pickle.load(open(filename, 'rb'))\n",
     "result = loaded_model.predict_proba(X)\n",
     "print(result)"
@@ -2046,47 +2048,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Get Threshold of Top 1% of data\n",
+    "# Get Threshold of Top ~2% of data\n",
     "\n",
     "Really this should be done with a holdout set, but I don't have enough data right now so I'm just going to generate it from the in-sample data. We can always adjust the threshold later."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T18:39:39.824970Z",
-     "start_time": "2023-05-10T18:39:39.749010Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "total posts: 5627, viral posts: 147\n"
-     ]
-    }
-   ],
-   "source": [
-    "filename = './pickledModels/Reddit_model_20230503-235329_GBM.sav'\n",
-    "model = pickle.load(open(filename, 'rb'))\n",
-    "\n",
-    "features = model.feature_names_in_\n",
-    "X = df[features]\n",
-    "y = df['target']\n",
-    "print(f\"total posts: {len(y)}, viral posts: {y.sum()}\")  # how many targets are there, This is a highly imbalanced problem, only ~2.5% of posts in rising go viral\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-05-10T18:39:42.361717Z",
-     "start_time": "2023-05-10T18:39:41.636684Z"
+     "end_time": "2023-05-03T23:54:06.022065Z",
+     "start_time": "2023-05-03T23:54:05.360199Z"
     }
    },
    "outputs": [
@@ -2119,7 +2092,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Taking the top ~1% to get higher precision and reduce spame from the subreddits this wasn't trained on."
+    "Based on these curves I'm going to take the top 3%. Precision is pretty stable between 97-98% and recall bumps a bit at 97% so it seems like a reasonable selection"
    ]
   },
   {
@@ -2127,15 +2100,15 @@
    "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T19:00:27.580940Z",
-     "start_time": "2023-05-10T19:00:27.482122Z"
+     "end_time": "2023-05-03T23:54:08.962647Z",
+     "start_time": "2023-05-03T23:54:08.887667Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.2941209400738473"
+       "0.129653657006705"
       ]
      },
      "execution_count": 19,
@@ -2144,17 +2117,17 @@
     }
    ],
    "source": [
-    "threshold = np.quantile(y_pred_proba, 0.99)\n",
+    "threshold = np.quantile(y_pred_proba, 0.97)\n",
     "threshold"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-05-10T19:08:19.134536Z",
-     "start_time": "2023-05-10T19:08:19.003644Z"
+     "end_time": "2023-05-03T23:54:45.725540Z",
+     "start_time": "2023-05-03T23:54:45.595065Z"
     },
     "scrolled": false
    },
@@ -2163,8 +2136,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "recall = 0.3469387755102041\n",
-      "precision = 0.8793103448275862\n"
+      "recall = 0.7006802721088435\n",
+      "precision = 0.6094674556213018\n"
      ]
     },
     {
@@ -2287,78 +2260,78 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5250</th>\n",
+       "      <th>2906</th>\n",
        "      <td>0</td>\n",
-       "      <td>132itl0</td>\n",
-       "      <td>https://reddit.com/132itl0</td>\n",
-       "      <td>0.320919</td>\n",
-       "      <td>2023-04-29 04:09:53+00:00</td>\n",
-       "      <td>75.0</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>1.00</td>\n",
-       "      <td>1.272727</td>\n",
-       "      <td>0.777778</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5105</th>\n",
-       "      <td>0</td>\n",
-       "      <td>12z0e15</td>\n",
-       "      <td>https://reddit.com/12z0e15</td>\n",
-       "      <td>0.310657</td>\n",
-       "      <td>2023-04-25 23:57:03+00:00</td>\n",
-       "      <td>111.0</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>7.0</td>\n",
+       "      <td>1302vkv</td>\n",
+       "      <td>https://reddit.com/1302vkv</td>\n",
+       "      <td>0.142015</td>\n",
+       "      <td>2023-04-26 23:13:55+00:00</td>\n",
+       "      <td>41.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>10.0</td>\n",
        "      <td>0.94</td>\n",
-       "      <td>0.947368</td>\n",
-       "      <td>1.333333</td>\n",
+       "      <td>0.518519</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>803</th>\n",
+       "      <th>726</th>\n",
        "      <td>0</td>\n",
-       "      <td>12vs177</td>\n",
-       "      <td>https://reddit.com/12vs177</td>\n",
-       "      <td>0.306409</td>\n",
-       "      <td>2023-04-23 02:15:49+00:00</td>\n",
-       "      <td>81.0</td>\n",
-       "      <td>7.0</td>\n",
-       "      <td>14.0</td>\n",
-       "      <td>0.93</td>\n",
-       "      <td>1.076923</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>131</th>\n",
-       "      <td>0</td>\n",
-       "      <td>12pg4tm</td>\n",
-       "      <td>https://reddit.com/12pg4tm</td>\n",
-       "      <td>0.294121</td>\n",
-       "      <td>2023-04-17 13:33:03+00:00</td>\n",
-       "      <td>65.0</td>\n",
-       "      <td>7.0</td>\n",
-       "      <td>12.0</td>\n",
-       "      <td>0.97</td>\n",
-       "      <td>1.096774</td>\n",
-       "      <td>0.714286</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2401</th>\n",
-       "      <td>0</td>\n",
-       "      <td>12q1sh3</td>\n",
-       "      <td>https://reddit.com/12q1sh3</td>\n",
-       "      <td>0.294121</td>\n",
-       "      <td>2023-04-17 23:38:19+00:00</td>\n",
-       "      <td>79.0</td>\n",
+       "      <td>12wyw1v</td>\n",
+       "      <td>https://reddit.com/12wyw1v</td>\n",
+       "      <td>0.142015</td>\n",
+       "      <td>2023-04-24 01:58:52+00:00</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>10.0</td>\n",
        "      <td>11.0</td>\n",
-       "      <td>15.0</td>\n",
-       "      <td>0.98</td>\n",
-       "      <td>1.194444</td>\n",
-       "      <td>0.363636</td>\n",
+       "      <td>0.97</td>\n",
+       "      <td>0.590909</td>\n",
+       "      <td>0.100000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3133</th>\n",
+       "      <td>0</td>\n",
+       "      <td>12tlnja</td>\n",
+       "      <td>https://reddit.com/12tlnja</td>\n",
+       "      <td>0.142015</td>\n",
+       "      <td>2023-04-21 01:13:33+00:00</td>\n",
+       "      <td>31.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>0.96</td>\n",
+       "      <td>0.631579</td>\n",
+       "      <td>1.500000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4332</th>\n",
+       "      <td>0</td>\n",
+       "      <td>12ue5r6</td>\n",
+       "      <td>https://reddit.com/12ue5r6</td>\n",
+       "      <td>0.140799</td>\n",
+       "      <td>2023-04-21 18:48:27+00:00</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>0.96</td>\n",
+       "      <td>0.764706</td>\n",
+       "      <td>0.142857</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4370</th>\n",
+       "      <td>0</td>\n",
+       "      <td>12rv1pg</td>\n",
+       "      <td>https://reddit.com/12rv1pg</td>\n",
+       "      <td>0.140799</td>\n",
+       "      <td>2023-04-19 14:26:37+00:00</td>\n",
+       "      <td>38.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>0.96</td>\n",
+       "      <td>0.809524</td>\n",
+       "      <td>0.142857</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>154 rows × 11 columns</p>\n",
+       "<p>213 rows × 11 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -2369,11 +2342,11 @@
        "1919       1  12mh34c  https://reddit.com/12mh34c    0.424945   \n",
        "3479       1  12z2v8n  https://reddit.com/12z2v8n    0.424945   \n",
        "...      ...      ...                         ...         ...   \n",
-       "5250       0  132itl0  https://reddit.com/132itl0    0.320919   \n",
-       "5105       0  12z0e15  https://reddit.com/12z0e15    0.310657   \n",
-       "803        0  12vs177  https://reddit.com/12vs177    0.306409   \n",
-       "131        0  12pg4tm  https://reddit.com/12pg4tm    0.294121   \n",
-       "2401       0  12q1sh3  https://reddit.com/12q1sh3    0.294121   \n",
+       "2906       0  1302vkv  https://reddit.com/1302vkv    0.142015   \n",
+       "726        0  12wyw1v  https://reddit.com/12wyw1v    0.142015   \n",
+       "3133       0  12tlnja  https://reddit.com/12tlnja    0.142015   \n",
+       "4332       0  12ue5r6  https://reddit.com/12ue5r6    0.140799   \n",
+       "4370       0  12rv1pg  https://reddit.com/12rv1pg    0.140799   \n",
        "\n",
        "                  createdTSUTC  maxScore41_60m  maxNumComments21_40m  \\\n",
        "3651 2023-05-02 16:56:49+00:00           301.0                  13.0   \n",
@@ -2382,11 +2355,11 @@
        "1919 2023-04-14 23:04:35+00:00           661.0                  87.0   \n",
        "3479 2023-04-26 01:48:36+00:00           180.0                  29.0   \n",
        "...                        ...             ...                   ...   \n",
-       "5250 2023-04-29 04:09:53+00:00            75.0                   9.0   \n",
-       "5105 2023-04-25 23:57:03+00:00           111.0                   3.0   \n",
-       "803  2023-04-23 02:15:49+00:00            81.0                   7.0   \n",
-       "131  2023-04-17 13:33:03+00:00            65.0                   7.0   \n",
-       "2401 2023-04-17 23:38:19+00:00            79.0                  11.0   \n",
+       "2906 2023-04-26 23:13:55+00:00            41.0                  10.0   \n",
+       "726  2023-04-24 01:58:52+00:00            35.0                  10.0   \n",
+       "3133 2023-04-21 01:13:33+00:00            31.0                   4.0   \n",
+       "4332 2023-04-21 18:48:27+00:00            30.0                   7.0   \n",
+       "4370 2023-04-19 14:26:37+00:00            38.0                   7.0   \n",
        "\n",
        "      maxNumComments41_60m  maxUpvoteRatio41_60m  maxScoreGrowth21_40m41_60m  \\\n",
        "3651                  41.0                  0.90                    2.762500   \n",
@@ -2395,11 +2368,11 @@
        "1919                 231.0                  0.92                    3.755396   \n",
        "3479                  51.0                  0.90                    2.103448   \n",
        "...                    ...                   ...                         ...   \n",
-       "5250                  16.0                  1.00                    1.272727   \n",
-       "5105                   7.0                  0.94                    0.947368   \n",
-       "803                   14.0                  0.93                    1.076923   \n",
-       "131                   12.0                  0.97                    1.096774   \n",
-       "2401                  15.0                  0.98                    1.194444   \n",
+       "2906                  10.0                  0.94                    0.518519   \n",
+       "726                   11.0                  0.97                    0.590909   \n",
+       "3133                  10.0                  0.96                    0.631579   \n",
+       "4332                   8.0                  0.96                    0.764706   \n",
+       "4370                   8.0                  0.96                    0.809524   \n",
        "\n",
        "      maxNumCommentsGrowth21_40m41_60m  \n",
        "3651                          2.153846  \n",
@@ -2408,32 +2381,32 @@
        "1919                          1.655172  \n",
        "3479                          0.758621  \n",
        "...                                ...  \n",
-       "5250                          0.777778  \n",
-       "5105                          1.333333  \n",
-       "803                           1.000000  \n",
-       "131                           0.714286  \n",
-       "2401                          0.363636  \n",
+       "2906                          0.000000  \n",
+       "726                           0.100000  \n",
+       "3133                          1.500000  \n",
+       "4332                          0.142857  \n",
+       "4370                          0.142857  \n",
        "\n",
-       "[154 rows x 11 columns]"
+       "[213 rows x 11 columns]"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# this was defined earlier, not that it's overfit, because it's evaluating on trained data\n",
-    "getOriginalPostId(df, list(range(len(df))), y, y_pred_proba, threshold, list(features))"
+    "getOriginalPostId(df, list(range(len(df))), y, y_pred_proba, threshold)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If there are 250 posts per day reaching r/pics/rising, then this means we will find about 2.5 posts on average.\n",
+    "If there are 250 posts per day reaching r/pics/rising, then this means we will find about 7.5 posts on average.\n",
     "\n",
-    "Of those 2.5 posts, 2 of them will be viral (0.8 precision) and this will be out of 7.5 posts that go viral (0.33 recall, those that reach top 3 of Hot). \n",
+    "Of those 7.5 posts, 4.5 of them will be viral (0.6 precision) and this will be out of 6.4 posts that go viral (reach top 3 of Hot). \n",
     "\n",
     "Once more data is collected this should be rerun to determine the proper out of sample scoring threshold."
    ]

--- a/model/test_model.py
+++ b/model/test_model.py
@@ -225,7 +225,7 @@ def test_filterExistingData(aggDataDf, engine, pipeline):
     pytest.skip("No engine")
   aggData = pipeline.createPredictions(aggDataDf)
   aggData = pipeline.markStepUp(aggData)
-  aggData = pipeline.filterExistingData(data=aggData)
+  aggData = pipeline.filterPreviousViralData(data=aggData)
   print(f"Data count after filtering existing data: {len(aggData)}")
 
 
@@ -253,6 +253,6 @@ def test_load(aggDataDf, engine, pipeline):
     pytest.skip("No engine")
   aggData = pipeline.createPredictions(aggDataDf)
   aggData = pipeline.markStepUp(aggData)
-  aggData = pipeline.filterExistingData(data=aggData)
+  aggData = pipeline.filterPreviousViralData(data=aggData)
   viralData = aggData[aggData['stepUp'] == 1]
   pipeline.load(data=viralData, tableName='scoredData')

--- a/scripts/buildAndPushDockerImage.sh
+++ b/scripts/buildAndPushDockerImage.sh
@@ -18,9 +18,14 @@ chmod +x PredictETL.py
 # make it so we can write the latest model from S3 to the pickledModels directory
 chmod -R +w pickledModels/
 
-# build the
+# build the environment image
 echo "Building predict-etl-packages image"
 docker build -t predict-etl-packages:latest -f ./Dockerfile.packages .
+
+# copy configUtils, wasn't needed for the environment image
+cp ../configUtils.py .
+
+# build the predict-etl image
 echo "Building predict-etl image"
 docker build -t predict-etl:latest -f ./Dockerfile .
 
@@ -28,3 +33,6 @@ docker build -t predict-etl:latest -f ./Dockerfile .
 aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${account_number}.dkr.ecr.us-east-2.amazonaws.com
 docker tag predict-etl:latest ${account_number}.dkr.ecr.us-east-2.amazonaws.com/predict-etl:latest
 docker push ${account_number}.dkr.ecr.us-east-2.amazonaws.com/predict-etl:latest
+
+# remove configUtils
+rm ./configUtils.py


### PR DESCRIPTION
This PR adds support for multiple subreddits addressing #18. 

I'd already tested and deployed the lambda function that collects data on the new subreddits (the container hat handles the PredictETL job automatically found these) the bot was reporting a lot of non-viral posts (poor precision because a lot of subreddits have higher activity than r/pics which the model was trained on). So I went reran the model evaluation to get the threshold for 1% of step ups. This lowers the recall quite a bit but will have higher precision and reduce the spam I was being notified for. 

There's also an adjustment here for #20 where the discord notification now has information on the 40-60 upvote score and replies (replies were available in the embeded post details, but score is generally hidden). 